### PR TITLE
fix: 이름으로 조회 시 5개 수동 페이지 개발에서 4개 slice 사용으로 수정

### DIFF
--- a/src/main/java/com/example/everguide/repository/CustomJobRepository.java
+++ b/src/main/java/com/example/everguide/repository/CustomJobRepository.java
@@ -5,6 +5,7 @@ import com.example.everguide.domain.Member;
 import com.example.everguide.domain.enums.Region;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 
@@ -14,5 +15,5 @@ public interface CustomJobRepository {
 
 
     List<Job> findThisWeekJobList();
-    List<Job> SearchJobListByName(String name, Pageable pageable);
+    Slice<Job> searchJobListByName(String name, Pageable pageable);
 }

--- a/src/main/java/com/example/everguide/repository/EducationRepository.java
+++ b/src/main/java/com/example/everguide/repository/EducationRepository.java
@@ -9,5 +9,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface EducationRepository extends JpaRepository<Education, Long> {
-    Page<Education> findAllByOrderByEndDateAsc(Pageable pageable);
+    Slice<Education> findAllByOrderByEndDateAsc(Pageable pageable);
 }

--- a/src/main/java/com/example/everguide/service/education/EducationMappingService.java
+++ b/src/main/java/com/example/everguide/service/education/EducationMappingService.java
@@ -3,11 +3,12 @@ package com.example.everguide.service.education;
 
 import com.example.everguide.domain.Education;
 import com.example.everguide.web.dto.education.EducationResponse;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 
 public class EducationMappingService {
-    public static EducationResponse.GetWorthToGoListDto toGetWorthToGoResultDto(List<Education> educations) {
+    public static EducationResponse.GetWorthToGoListDto toGetWorthToGoResultDto(Slice<Education> educations) {
         List<EducationResponse.GetWorthToGoDto> educationList = educations.stream()
                 .map(education ->
                         EducationResponse.GetWorthToGoDto.builder()
@@ -18,13 +19,10 @@ public class EducationMappingService {
                                 .build()).toList();
         return EducationResponse.GetWorthToGoListDto.builder()
                 .educationList(educationList)
-                .hasMore(calcHasMore(educationList)). //다음페이지 존재 여부
+                .hasMore(educations.hasNext()). //다음페이지 존재 여부
                 build();
 
 
     }
 
-    private static Boolean calcHasMore(List<EducationResponse.GetWorthToGoDto> educationList) {
-        return educationList.size() == 5;
-    }
 }

--- a/src/main/java/com/example/everguide/service/education/EducationService.java
+++ b/src/main/java/com/example/everguide/service/education/EducationService.java
@@ -4,16 +4,15 @@ import com.example.everguide.domain.Education;
 import com.example.everguide.repository.EducationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class EducationService {
     private final EducationRepository educationRepository;
 
-    public List<Education> getWorthToGoList(Pageable pageable) {
-        return educationRepository.findAllByOrderByEndDateAsc(pageable).getContent();
+    public Slice<Education> getWorthToGoList(Pageable pageable) {
+        return educationRepository.findAllByOrderByEndDateAsc(pageable);
     }
 }

--- a/src/main/java/com/example/everguide/service/job/JobMappingService.java
+++ b/src/main/java/com/example/everguide/service/job/JobMappingService.java
@@ -12,6 +12,7 @@ import com.example.everguide.web.dto.job.JobItem;
 import com.example.everguide.web.dto.job.JobItemDetail;
 import com.example.everguide.web.dto.job.JobResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -27,31 +28,28 @@ public class JobMappingService {
 
 
     //로그인 했을 때, 검색결과
-    public JobResponse.GetJobListSearchByName toGetJobListSearchByName(List<Job> jobs, Member member) {
+    public JobResponse.GetJobListSearchByName toGetJobListSearchByName(Slice<Job> jobs, Member member) {
         List<JobResponse.JobDto> jobList = jobs.stream()
                 .map(job -> this.toJobDto(job, member))
                 .collect(Collectors.toList());
         return JobResponse.GetJobListSearchByName.builder()
                 .jobDtoList(jobList)
-                .hasMore(calcHasNext(jobs))
+                .hasMore(jobs.hasNext())
                 .build();
     }
 
 
     //로그인 안했을 때, 검색결과
-    public JobResponse.GetJobListSearchByName toNoLoginGetJobListSearchByName(List<Job> jobs) {
+    public JobResponse.GetJobListSearchByName toNoLoginGetJobListSearchByName(Slice<Job> jobs) {
         List<JobResponse.JobDto> jobList = jobs.stream()
                 .map(this::toNoLoginJobDto)
                 .collect(Collectors.toList());
         return JobResponse.GetJobListSearchByName.builder()
                 .jobDtoList(jobList)
-                .hasMore(calcHasNext(jobs))
+                .hasMore(jobs.hasNext())
                 .build();
     }
 
-    private Boolean calcHasNext(List<Job> jobs) {
-        return jobs.size() == 5;
-    }
 
 
     public  JobResponse.GetJobList toNoLoginJobListDto(List<Job> jobs) {

--- a/src/main/java/com/example/everguide/service/job/JobService.java
+++ b/src/main/java/com/example/everguide/service/job/JobService.java
@@ -106,7 +106,7 @@ public class JobService {
     //로그인 안했을 때, 검색 기능
     @Transactional(readOnly = true)
     public JobResponse.GetJobListSearchByName noLoginSearchJobListByName(String keyword, Pageable pageable) {
-        return jobMappingService.toNoLoginGetJobListSearchByName(jobRepository.SearchJobListByName(keyword, pageable));
+        return jobMappingService.toNoLoginGetJobListSearchByName(jobRepository.searchJobListByName(keyword, pageable));
     }
 
 
@@ -115,7 +115,7 @@ public class JobService {
     public JobResponse.GetJobListSearchByName SearchJobListByName(String keyword, Pageable pageable) {
         String userId = securityUtil.getCurrentUserId();
         Member member = memberRepository.findByUserId(userId).orElseThrow(EntityNotFoundException::new);
-        return jobMappingService.toGetJobListSearchByName(jobRepository.SearchJobListByName(keyword, pageable), member);
+        return jobMappingService.toGetJobListSearchByName(jobRepository.searchJobListByName(keyword, pageable), member);
     }
 
 

--- a/src/main/java/com/example/everguide/web/controller/JobController.java
+++ b/src/main/java/com/example/everguide/web/controller/JobController.java
@@ -59,7 +59,7 @@ public class JobController {
     @GetMapping("/jobs/getJobListSearchByName")
     public ResponseEntity<ApiResponse<JobResponse.GetJobListSearchByName>> getJobListSearchByName(@RequestParam(value = "name") String name,
                                                                          @RequestParam(value = "page", required = false, defaultValue = "1") Integer page,
-                                                                         @RequestParam(value = "size", required = false, defaultValue = "5") Integer size
+                                                                         @RequestParam(value = "size", required = false, defaultValue = "4") Integer size
                                                                          ) {
         Pageable pageable = PageRequest.of(page - 1, size);
         return ResponseEntity.ok(ApiResponse.onSuccess(SuccessStatus._OK, jobService.noLoginSearchJobListByName(name, pageable)));
@@ -84,7 +84,7 @@ public class JobController {
     public ResponseEntity<ApiResponse<JobResponse.GetJobListSearchByName>> getJobListSearchByName(@RequestParam(value = "name") String name,
                                                                                                   @RequestParam(value = "memberId") Long memberId,
                                                                                                   @RequestParam(value = "page", required = false, defaultValue = "1") Integer page,
-                                                                                                  @RequestParam(value = "size", required = false, defaultValue = "5") Integer size
+                                                                                                  @RequestParam(value = "size", required = false, defaultValue = "4") Integer size
     ) {
 
         Pageable pageable = PageRequest.of(page - 1, size);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
fix: 이름으로 조회 시 5개 수동 페이지 개발에서 4개 slice 사용으로 수정

## ✍🏻 작업 내용

기존에 5개씩 조회해서, 페이지 설정 오류 및 5개씩 정보가 가능 오류 발견
slice 사용으로 해결

## 💬 리뷰 요구사항(선택)
